### PR TITLE
feat: add copy feature to response block 

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -34,9 +34,10 @@ td {
   padding: 8px;
 }
 
-thead > tr {
+thead>tr {
   border-bottom: 1px solid #ddd;
 }
+
 tr:nth-child(even) {
   background-color: #d6eeee;
 }
@@ -168,6 +169,7 @@ li span:nth-child(1) {
 .route-item[style='display: none;'] {
   display: none !important;
 }
+
 .hide {
   display: none;
 }
@@ -205,7 +207,7 @@ li span:nth-child(1) {
   }
 }
 
-.notes > p {
+.notes>p {
   color: #777;
   text-align: left;
   font-size: 14px;
@@ -224,8 +226,71 @@ li span:nth-child(1) {
   color: white;
 }
 
-.no-content > div {
+.no-content>div {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+/* Copy button and response section styles */
+.response-section {
+  margin-top: 20px;
+}
+
+.response-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.response-header h3 {
+  margin: 0;
+}
+
+.copy-btn {
+  background-color: #f8f9fa;
+  color: #495057;
+  border: 1px solid #dee2e6;
+  padding: 8px 12px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.copy-btn:hover {
+  background-color: #e9ecef;
+  border-color: #adb5bd;
+}
+
+.copy-btn:active {
+  background-color: #dee2e6;
+}
+
+.copy-btn.copied {
+  background-color: #d4edda;
+  color: #155724;
+  border-color: #c3e6cb;
+}
+
+.copy-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Responsive adjustments for copy button */
+@media screen and (max-width: 1440px) {
+  .response-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .copy-btn {
+    font-size: 0.8rem;
+    padding: 6px 10px;
+  }
 }

--- a/public/main.js
+++ b/public/main.js
@@ -66,6 +66,50 @@ function getStatus() {
   return status
 }
 
+// Function to copy response table content to clipboard
+function copyResponseTable() {
+  let responseText = `Response Messages for ${currentRoute.method.toUpperCase()} ${currentRoute.path}\n\n`
+  responseText += 'HTTP Status Code | Reason\n'
+  responseText += '-----------------|-------\n'
+
+  for (const statusCode in currentRoute?.responses) {
+    responseText += `${statusCode} | ${currentRoute?.responses[statusCode]}\n`
+  }
+
+  navigator.clipboard.writeText(responseText).then(() => {
+    // Show success feedback
+    const copyBtn = document.getElementById('copy-response-btn')
+    const originalText = copyBtn.textContent
+    copyBtn.textContent = 'Copied!'
+    copyBtn.classList.add('copied')
+
+    setTimeout(() => {
+      copyBtn.textContent = originalText
+      copyBtn.classList.remove('copied')
+    }, 2000)
+  }).catch(err => {
+    console.error('Failed to copy: ', err)
+    // Fallback for older browsers
+    const textArea = document.createElement('textarea')
+    textArea.value = responseText
+    document.body.appendChild(textArea)
+    textArea.select()
+    document.execCommand('copy')
+    document.body.removeChild(textArea)
+
+    // Show success feedback
+    const copyBtn = document.getElementById('copy-response-btn')
+    const originalText = copyBtn.textContent
+    copyBtn.textContent = 'Copied!'
+    copyBtn.classList.add('copied')
+
+    setTimeout(() => {
+      copyBtn.textContent = originalText
+      copyBtn.classList.remove('copied')
+    }, 2000)
+  })
+}
+
 function renderRoutePage() {
   const routes = document.getElementById('routes')
   const app = document.getElementById('app')
@@ -90,9 +134,18 @@ function renderRoutePage() {
         <span class="">${currentRoute?.description || 'Not provided'}</span>
       </li>
 
-      <div class="">
-        <h3>Response messages</h3>
-        <table>
+      <div class="response-section">
+        <div class="response-header">
+          <h3>Response messages</h3>
+          <button id="copy-response-btn" class="btn copy-btn" onclick="copyResponseTable()">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M20 9H11C9.89543 9 9 9.89543 9 11V20C9 21.1046 9.89543 22 11 22H20C21.1046 22 22 21.1046 22 20V11C22 9.89543 21.1046 9 20 9Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M5 15H4C2.89543 15 2 14.1046 2 13V4C2 2.89543 2.89543 2 4 2H13C14.1046 2 15 2.89543 15 4V5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            Copy
+          </button>
+        </div>
+        <table id="response-table">
           <thead>
             <tr>
               <th>HTTP Status Code</th>


### PR DESCRIPTION
Adds a copy button to the response messages table that allows users to copy response data to clipboard.

## Changes Made
- Add copy button with SVG icon to response table header
- Implement copyResponseTable() function with clipboard API support
- Add CSS styling for copy button (hover, active, success states)
- Include responsive design for mobile devices
- Support both modern browsers and fallback for older ones

## How it works
- Click copy button in response messages section
- Response data is formatted and copied to clipboard
- Button shows "Copied!" feedback for 2 seconds
- Works across all browsers with fallback support

Closes #40