### PR TITLE
feat: add copy button to API response block

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -237,6 +237,20 @@ function resultsFn(data, err) {
   }`
 }
 
+function copyResponse() {
+  const responseTextElement = document.getElementById('responseText')
+  if (!responseTextElement) {
+    alert('No response text to copy!')
+    return
+  }
+  const textToCopy = responseTextElement.innerText || responseTextElement.textContent
+  navigator.clipboard.writeText(textToCopy).then(() => {
+    alert('Response copied to clipboard!')
+  }).catch((err) => {
+    alert('Failed to copy text: ' + err)
+  })
+}
+
 //////////////////////////////////////<-PAGES->//////////////////////////////////////////////
 
 const routes = {


### PR DESCRIPTION
This PR adds a "copy" button to the API response block, enabling users to quickly copy the JSON response content to their clipboard. It improves usability and debugging convenience.